### PR TITLE
separate reducers for players and winning score

### DIFF
--- a/scorekeeper-redux/src/components/Counter.js
+++ b/scorekeeper-redux/src/components/Counter.js
@@ -33,7 +33,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProp(state) {
   console.log('winning score', state);
   return {
-    count: state.count
+    count: state.winnerReducer.count
   }
 }
 

--- a/scorekeeper-redux/src/components/PlayerOne.js
+++ b/scorekeeper-redux/src/components/PlayerOne.js
@@ -28,7 +28,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProp(state) {
   console.log('player one score', state);
   return {
-    playerOne: state.playerOne
+    playerOne: state.playerReducer.playerOne
   }
 }
 

--- a/scorekeeper-redux/src/components/PlayerTwo.js
+++ b/scorekeeper-redux/src/components/PlayerTwo.js
@@ -28,7 +28,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProp(state) {
   console.log('player two score', state);
   return {
-    playerTwo: state.playerTwo
+    playerTwo: state.playerReducer.playerTwo
   }
 }
 //connect component to store

--- a/scorekeeper-redux/src/store/index.js
+++ b/scorekeeper-redux/src/store/index.js
@@ -1,21 +1,15 @@
-import { createStore } from 'redux';
+import { createStore, combineReducers } from 'redux';
 
-//initial state of winning score, player 1 score and player 2 score
-const initialState = {
-  count: 5,
+//initial state and player 1 score and player 2 score
+const playerDefaultState = {
   playerOne: 0,
   playerTwo: 0
 };
 
 //reducer function for updating object 
-const reducer = (state = initialState, action) => {
-  console.log('reducer running', action);
-
+const playerReducer = (state = playerDefaultState, action) => {
+  console.log('player reducer running', action);
   switch(action.type) {
-    case 'INCREMENT':
-      return Object.assign({}, state, {count: state.count + 1 });
-    case 'DECREMENT':
-      return Object.assign({}, state, {count: state.count - 1});
     case 'INCREMENTONE':
       return Object.assign({}, state, {playerOne: state.playerOne + 1});
     case 'INCREMENTTWO':
@@ -24,8 +18,37 @@ const reducer = (state = initialState, action) => {
       return state;
   }
 }
-//redux state container
-const store = createStore(reducer);
+
+//initial state of winning score
+const winnerDefaultState = {
+  count: 5
+}
+
+//reducer function for updating winning score 
+const winnerReducer = (state = winnerDefaultState, action) => {
+  console.log('winner reducer running', action);
+  switch (action.type) {
+    case 'INCREMENT':
+      return Object.assign({}, state, {
+        count: state.count + 1
+      });
+    case 'DECREMENT':
+      return Object.assign({}, state, {
+        count: state.count - 1
+      });
+    default:
+      return state;
+  }
+}
+
+// redux state container
+const store = createStore(
+  combineReducers({
+    playerReducer,
+    winnerReducer
+  })
+);
+
 
 export default store;
 


### PR DESCRIPTION
- properly referenced the *reducer object* in each component's `mapStateToProp` function
- add `combineReducer` for splitting reducers
 - create separate reducers object for `winnerReducer` and `playerReducer` to independently manage different parts of the state. 