### PR TITLE
prevent game from being a tie

### DIFF
--- a/scorekeeper-redux/src/containers/PlayerOneComponent.js
+++ b/scorekeeper-redux/src/containers/PlayerOneComponent.js
@@ -9,15 +9,42 @@ class PlayerOneComponent extends Component {
   }
   render() {
     const {playerOne}=this.props
+    const {playerTwo}=this.props
     const {gameScore}=this.props
+
+    /* logic for disabling player 1 button if player 1 or player 2 
+    score matches game score */
+    let incrementButtonOne;
+    if(gameScore === playerOne) {
+      incrementButtonOne = (
+        <Button 
+          action={this.incrementPlayerOne}
+          buttonTitle='+'
+          disabled={true}
+        />
+      )
+    } else if(gameScore === playerTwo) {
+      incrementButtonOne = (
+        <Button 
+          action={this.incrementPlayerOne}
+          buttonTitle='+'
+          disabled={true}
+        />
+      )
+    } else {
+      incrementButtonOne = (
+        <Button 
+          action={this.incrementPlayerOne}
+          buttonTitle='+'
+          disabled={false}
+        />
+      )
+    }
+    
     return (
       <div>
         <h1>Player 1 Score: {playerOne}</h1>
-        <Button 
-          action={this.incrementPlayerOne} 
-          buttonTitle ='+'
-          disabled={playerOne === gameScore ? true:false} 
-        />
+        {incrementButtonOne}
       </div>
     );
   }
@@ -28,6 +55,7 @@ const mapStateToProps = (state) => {
   console.log('Player 1 score', state)
   return {
     playerOne: state.playerOneReducer.playerOne,
+    playerTwo: state.playerTwoReducer.playerTwo,
     gameScore: state.gameScoreReducer.gameScore
   }
 }

--- a/scorekeeper-redux/src/containers/PlayerTwoComponent.js
+++ b/scorekeeper-redux/src/containers/PlayerTwoComponent.js
@@ -8,16 +8,42 @@ class PlayerTwoComponent extends Component {
     this.props.onIncrementTwo(this.props.playerTwo)
   }
   render() {
+    const {playerOne}=this.props
     const {playerTwo}=this.props
     const {gameScore}=this.props
+
+     /* logic for disabling player 2 button if player 2 or player 1 
+    score matches game score */
+    let incrementButtonTwo;
+    if(gameScore === playerTwo) {
+      incrementButtonTwo = (
+        <Button 
+          action={this.incrementPlayerTwo}
+          buttonTitle='+'
+          disabled={true}
+        />
+      )
+    } else if(gameScore === playerOne) {
+      incrementButtonTwo = (
+        <Button 
+          action={this.incrementPlayerTwo}
+          buttonTitle='+'
+          disabled={true}
+        />
+      )
+    } else {
+      incrementButtonTwo = (  
+        <Button 
+          action={this.incrementPlayerTwo}
+          buttonTitle='+'
+          disabled={false}
+        />
+      )
+    }
     return (
       <div>
         <h1>Player 2 Score: {playerTwo}</h1>
-        <Button
-         action={this.incrementPlayerTwo} 
-         buttonTitle ='+'
-         disabled={playerTwo === gameScore ? true:false}
-         />
+        {incrementButtonTwo}
       </div>
     );
   }
@@ -27,6 +53,7 @@ class PlayerTwoComponent extends Component {
 const mapStateToProps = (state) => {
   console.log('Player 2 score', state)
   return {
+    playerOne: state.playerOneReducer.playerOne,
     playerTwo: state.playerTwoReducer.playerTwo,
     gameScore: state.gameScoreReducer.gameScore
   }


### PR DESCRIPTION
- update conditional logic to disable `playerOne` and `playerTwo` buttons when there is a winner
 - this will prevent final scores for both players being a tie