### PR TITLE
evenly split mobile responsive components

### DIFF
--- a/scorekeeper-redux/src/containers/GameScoreComponent.js
+++ b/scorekeeper-redux/src/containers/GameScoreComponent.js
@@ -51,7 +51,7 @@ class GameComponent extends Component {
       )  
     }
     return (
-      <div className='game-score'>
+     
         <div className='game-score__title'>
           Playing up to: 
           <div className='game-score__winning-score'>
@@ -81,7 +81,7 @@ class GameComponent extends Component {
             />
           </div>
         </div>
-      </div>
+   
     );
   }
 }

--- a/scorekeeper-redux/src/containers/PlayerOneComponent.js
+++ b/scorekeeper-redux/src/containers/PlayerOneComponent.js
@@ -48,7 +48,7 @@ class PlayerOneComponent extends Component {
       )
     }
     return (
-      <div className='player-one'>
+      <div>
         <div className='player-one__title'>
           Player 1:
         </div>

--- a/scorekeeper-redux/src/containers/PlayerTwoComponent.js
+++ b/scorekeeper-redux/src/containers/PlayerTwoComponent.js
@@ -48,7 +48,7 @@ class PlayerTwoComponent extends Component {
       )
     }
     return (
-      <div className='player-two'>
+      <div>
         <div className='player-two__title'>
           Player 2:
         </div>

--- a/scorekeeper-redux/src/index.js
+++ b/scorekeeper-redux/src/index.js
@@ -10,11 +10,19 @@ import './styles/styles.scss';
 
 render(
   <Provider store={store}>
-  <div className='grid-container'>
     <Header />
-    <GameScoreComponent />
-    <PlayerOneComponent />
-    <PlayerTwoComponent />
+  <div className='container'>
+    <div className='grid-container'>
+      <div className='game-score'>
+        <GameScoreComponent />
+      </div>
+      <div className='player-one'>
+        <PlayerOneComponent />
+      </div>
+      <div className='player-two'>
+        <PlayerTwoComponent />
+      </div>
+    </div>
   </div>
   </Provider>
 

--- a/scorekeeper-redux/src/styles/base/_base.scss
+++ b/scorekeeper-redux/src/styles/base/_base.scss
@@ -11,3 +11,7 @@ body {
   font-family: Helvetica, Arial, sans-serif;
   font-size: $m-size;
 }
+
+.container {
+  max-width: 600px;
+}

--- a/scorekeeper-redux/src/styles/components/_game-score.scss
+++ b/scorekeeper-redux/src/styles/components/_game-score.scss
@@ -1,6 +1,9 @@
 .game-score {
   background: $blue;
   color: $off-white;
+  padding: 25px 175px 25px 175px;
+  border: 25px;
+  text-align: center;
 }
 
 .game-score__title {

--- a/scorekeeper-redux/src/styles/components/_grid.scss
+++ b/scorekeeper-redux/src/styles/components/_grid.scss
@@ -3,71 +3,26 @@
 @import './player-score';
 
 
+
 .grid-container {
   display: grid;
   grid-gap: 1px;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   grid-template-areas:
-    "header header header header"
-    "game-score game-score game-score game-score"
-    "player-one player-one player-two player-player-two"
-}
-
-.header {
-  grid-area: header;
+    "game-score game-score"
+    "player-one player-two"
 }
 
 .game-score {
   grid-area: game-score;
-  padding: 25px 175px 25px 175px; 
-  border: 25px;
-  text-align: center;
-  margin: auto;
 }
 
 .player-one {
   grid-area: player-one;
-  grid-column: 2/3;
-  padding: 15px 0 15px 0;
-  text-align: center;
 }
 
 .player-two {
   grid-area: player-two;
-  grid-column: 3/4;
-  padding: 15px 0 15px 0;
-  text-align: center;
 }
 
-//tablet view
-// @media only screen and (min-device-width: 768px) {
-//   .game-score {
-//     text-align: right;
-//   }
-
-//   .player-one {
-//     text-align: right;
-//   }
-
-//   .player-two {
-//     text-align: right;
-//   }
-// }
-
-//mobile view
-@media only screen and (min-device-width: 480px) {
-  .game-score {
-    text-align: center;
-  }
-  
-  .player-one {
-    text-align: center;
-    min-width: 200px;
-  }  
-
-  .player-two {
-    text-align: center;
-    min-width: 200px;
-  }
-}
 

--- a/scorekeeper-redux/src/styles/components/_player-score.scss
+++ b/scorekeeper-redux/src/styles/components/_player-score.scss
@@ -1,13 +1,13 @@
 .player-one, .player-two {
   background: $off-black;
   color: $off-white;
-  display: inline-block;
-  margin: $m-size;
+  padding: 15px 0 15px 0;
+  text-align: center;
 }
 
-.player-one__title, .player-two__title {
-  font-size: $m-size;
-}
+// .player-one__title, .player-two__title {
+//   font-size: $m-size;
+// }
 
 .player-one__score, .player-two__score {
   font-size: $xl-size;


### PR DESCRIPTION
- add new div containers with `classNames` in *index.js* for new *CSS grid layout*
- transfer property values from *game-score*, *player-one* and *player-two* to *grid.scss* 
- simplify `grid-container` for new *CSS grid layout*