### PR TITLE
decrease padding for mobile view

### DIFF
--- a/scorekeeper-redux/src/styles/components/_game-score.scss
+++ b/scorekeeper-redux/src/styles/components/_game-score.scss
@@ -1,7 +1,7 @@
 .game-score {
   background: $off-black;
   color: $off-white;
-  padding: 25px 175px 25px 175px;
+  padding: 25px 100px 25px 100px;
   border: .3rem solid lighten($off-black, 5%);
   text-align: center; 
 }


### PR DESCRIPTION
- decrease `game-score` padding to prevent horizontal scroll in mobile browser for Mozilla. 